### PR TITLE
Mesos protobuf

### DIFF
--- a/COMPILING.md
+++ b/COMPILING.md
@@ -2,7 +2,7 @@
 
 On the host
 
-    host> docker run -it ubuntu:14.04
+    host> docker run -it ubuntu:15.10
 
 Inside the container: Follow the instruction on
 [System Requirements](http://mesos.apache.org/gettingstarted/)
@@ -16,9 +16,8 @@ and clone mesos
 
     container> mkdir /home
     container> cd /home
-    container> git clone -b reservation https://github.com/mpark/mesos.git
+    container> git clone https://github.com/mesos/mesos.git
     container> cd mesos
-    container> git checkout 56cc41be9b18d3a15f1814327d01506742153305
 
 Follow the instructions
 [Building Mesos](http://mesos.apache.org/gettingstarted/)
@@ -28,12 +27,12 @@ and also install Mesos.
 
 Inside the container: Install the requirements.
 
-    container> apt-get install libprotobuf-dev libboost-dev libgoogle-glog-dev libmicrohttpd-dev 
+    container> apt-get install libboost-dev libgoogle-glog-dev libmicrohttpd-dev 
 
 Checkout and compile:
 
     container> cd /home
-    container> git clone https://github.com/fceller/arangodb-mesos.git
+    container> git clone https://github.com/arangodb/arangodb-mesos.git
     container> cd arangodb-mesos
     container> autoreconf
     container> ./configure

--- a/configure.ac
+++ b/configure.ac
@@ -112,27 +112,6 @@ LDFLAGS="${LDFLAGS} ${PTHREAD_CFLAGS}"
 LIBS="${LIBS} ${PTHREAD_LIBS} "
 
 dnl ----------------------------------------------------------------------------
-dnl protobuf
-dnl ----------------------------------------------------------------------------
-
-AC_LANG(C++)
-
-AC_CHECK_HEADERS(google/protobuf/stubs/common.h, [PROTOBUF=yes], [PROTOBUF=no])
-AC_MSG_CHECKING([PROTOBUF])
-
-if test "x$PROTOBUF" = "xno";  then
-  AC_MSG_ERROR([Please install 'libprotobuf-dev'])
-else
-  AC_MSG_RESULT([found])
-fi
-
-AC_CHECK_TOOL([PROTOCOMPILER], [protoc], [], [])
-
-if test "x$PROTOCOMPILER" = "x";  then
-  AC_MSG_ERROR([Please install 'protobuf-compiler'])
-fi
-
-dnl ----------------------------------------------------------------------------
 dnl glog
 dnl ----------------------------------------------------------------------------
 
@@ -181,11 +160,12 @@ dnl ----------------------------------------------------------------------------
 AC_LANG(C++)
 
 topdir="${ac_pwd}"
-MESOS_CPPFLAGS="-I${topdir}/mesos/include -I${topdir}/mesos/src -I${topdir}/mesos/build/include -I${topdir}/mesos/build/src -I${topdir}/mesos/3rdparty/libprocess/3rdparty/stout/include -I${topdir}/mesos/3rdparty/libprocess/include -I${topdir}/mesos/build/3rdparty/zookeeper-3.4.5/src/c/include -I${topdir}/mesos/build/3rdparty/zookeeper-3.4.5/src/c/generated"
+MESOS_CPPFLAGS="-I${topdir}/mesos/include -I${topdir}/mesos/src -I${topdir}/mesos/build/include -I${topdir}/mesos/build/src -I${topdir}/mesos/3rdparty/libprocess/3rdparty/stout/include -I${topdir}/mesos/3rdparty/libprocess/include -I${topdir}/mesos/build/3rdparty/zookeeper-3.4.5/src/c/include -I${topdir}/mesos/build/3rdparty/zookeeper-3.4.5/src/c/generated -I${topdir}/mesos/build/3rdparty/libprocess/3rdparty/protobuf-2.5.0/src"
 
 MESOS_LIBS="-L${topdir}/mesos/build/src/.libs -lmesos_no_3rdparty"
 MESOS_LIBS="${MESOS_LIBS} -L${topdir}/mesos/build/3rdparty/libprocess/.libs/ -lprocess"
 MESOS_LIBS="${MESOS_LIBS} -L${topdir}/mesos/build/3rdparty/libprocess/3rdparty/libev-4.15/.libs -lev"
+MESOS_LIBS="${MESOS_LIBS} -L${topdir}/mesos/build/3rdparty/libprocess/3rdparty/protobuf-2.5.0/src/.libs -lprotobuf"
 MESOS_LIBS="${MESOS_LIBS} ${topdir}/mesos/build/3rdparty/leveldb/libleveldb.a"
 MESOS_LIBS="${MESOS_LIBS} -L${topdir}/mesos/build/3rdparty/zookeeper-3.4.5/src/c/.libs -lzookeeper_mt"
 MESOS_LIBS="${MESOS_LIBS} -lprotobuf -lglog -lapr-1 -lsvn_delta-1 -lsvn_subr-1 -lcurl -lsasl2 -lz -ldl"


### PR DESCRIPTION
mesos uses its own bundled protobuf (version 2.5). currently the arangodb framework relies on a system installed protobuf. On newer (15.10 ubuntu) systems a newer version of protobuf is part of the system and that is incompatible. So instead of requiring a system protobuf just use the one mesos is using.